### PR TITLE
GalaxyWearable: Add Galaxy Buds FE Manager

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,7 @@ jobs:
           - package: com.samsung.accessory.fridaymgr
           - package: com.samsung.accessory.atticmgr
           - package: com.samsung.accessory.berrymgr
+          - package: com.samsung.accessory.pearlmgr
           - package: com.samsung.accessory.popcornmgr
           - package: com.samsung.accessory.neobeanmgr
       max-parallel: 1

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ You can download the apks from [Releases](https://github.com/Linux4/GalaxyWearab
 * atticmgr = Galaxy Buds Pro
 * berrymgr = Galaxy Buds2
 * neobeanmgr = Galaxy Buds Live
+* pearlmgr = Galaxy Buds FE
 * watchmanager = Samsung Gear (main application)
 * waterplugin = Galaxy Watch4
 * neatplugin = Galaxy Fit2


### PR DESCRIPTION
This PR adds support for Galaxy Buds FE (tested and everything is working fine)